### PR TITLE
Download helper utils during CI instead of building them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,11 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Prepare
-        run: make prepare
+        run: |
+          wget -O wasm-proc -P ~/.cargo/bin https://github.com/gear-tech/gear/releases/download/build/wasm-proc
+          chmod +x ~/.cargo/bin/wasm-proc
+          wget -O gtest -P ~/.cargo/bin https://github.com/gear-tech/gear/releases/download/build/gtest
+          chmod +x ~/.cargo/bin/gtest
 
       - name: Check fmt
         run: make fmt-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Prepare
         run: |
-          wget -O wasm-proc -P ~/.cargo/bin https://github.com/gear-tech/gear/releases/download/build/wasm-proc
+          wget -O ~/.cargo/bin/wasm-proc https://github.com/gear-tech/gear/releases/download/build/wasm-proc
           chmod +x ~/.cargo/bin/wasm-proc
-          wget -O gtest -P ~/.cargo/bin https://github.com/gear-tech/gear/releases/download/build/gtest
+          wget -O ~/.cargo/bin/gtest https://github.com/gear-tech/gear/releases/download/build/gtest
           chmod +x ~/.cargo/bin/gtest
 
       - name: Check fmt


### PR DESCRIPTION
- Download prebuilt helper utils (`wasm-proc`, `gtest`) in CI.