### PR TITLE
Update `demo-ping` to use new builder and test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +386,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 name = "demo-ping"
 version = "0.1.0"
 dependencies = [
+ "gear-wasm-builder",
  "gstd",
+ "gtest",
 ]
 
 [[package]]
@@ -510,7 +543,7 @@ dependencies = [
 [[package]]
 name = "galloc"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "dlmalloc",
 ]
@@ -518,15 +551,13 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 
 [[package]]
 name = "gear-backend-common"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
- "anyhow",
- "cfg-if",
  "gear-core",
  "log",
 ]
@@ -534,20 +565,17 @@ dependencies = [
 [[package]]
 name = "gear-backend-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
- "anyhow",
- "cfg-if",
  "gear-backend-common",
  "gear-core",
- "log",
  "wasmtime",
 ]
 
 [[package]]
 name = "gear-core"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -556,12 +584,13 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm",
  "pwasm-utils",
+ "scale-info",
 ]
 
 [[package]]
 name = "gear-core-processor"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "blake2-rfc",
  "gear-backend-common",
@@ -578,6 +607,18 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
+]
+
+[[package]]
+name = "gear-wasm-builder"
+version = "0.1.1"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "pwasm-utils",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -611,7 +652,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 [[package]]
 name = "gstd"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "bs58",
  "futures",
@@ -627,7 +668,7 @@ dependencies = [
 [[package]]
 name = "gstd-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "quote",
  "syn",
@@ -636,7 +677,7 @@ dependencies = [
 [[package]]
 name = "gtest"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#5d12a57500da45f30e0a86d525a3351a4a6961d0"
+source = "git+https://github.com/gear-tech/gear.git#e562ef66c51512e7004723c7bf1a3b48ec9a0f98"
 dependencies = [
  "colored",
  "env_logger",
@@ -735,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,7 +855,19 @@ name = "nft-example"
 version = "0.1.0"
 dependencies = [
  "gstd",
+ "gtest",
+ "nft-example-io",
  "non-fungible-token",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+]
+
+[[package]]
+name = "nft-example-io"
+version = "0.1.0"
+dependencies = [
+ "gstd",
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
@@ -1131,6 +1190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scale-info"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1230,9 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1184,6 +1252,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/ping/Cargo.toml
+++ b/ping/Cargo.toml
@@ -2,11 +2,14 @@
 name = "demo-ping"
 version = "0.1.0"
 authors = ["Gear Technologies"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
-gstd = {git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
+gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
+
+[build-dependencies]
+gear-wasm-builder = { git = "https://github.com/gear-tech/gear.git" }
+
+[dev-dependencies]
+gtest = { git = "https://github.com/gear-tech/gear.git" }

--- a/ping/build.rs
+++ b/ping/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    gear_wasm_builder::build();
+}

--- a/ping/src/lib.rs
+++ b/ping/src/lib.rs
@@ -21,5 +21,23 @@ pub unsafe extern "C" fn handle() {
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn init() {}
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use gtest::{Log, Program, System};
+
+    #[test]
+    fn it_works() {
+        let system = System::new();
+        system.init_logger();
+
+        let program = Program::current(&system);
+
+        let res = program.send_bytes(42, "INIT");
+        assert!(res.log().is_empty());
+
+        let res = program.send_bytes(42, "PING");
+        assert!(res.contains(&Log::builder().source(1).dest(42).payload_bytes("PONG")));
+    }
+}


### PR DESCRIPTION
`demo-ping`:

- Remove empty `init()`.
- Use `gear-wasm-buider`.
- Add a simple unit test.

@gear-tech/ecosystem-devs 
