### PR TITLE
Escrow smart contract update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "gstd",
  "gtest",
  "parity-scale-codec",
+ "primitive-types",
 ]
 
 [[package]]
@@ -537,6 +538,8 @@ version = "0.1.0"
 dependencies = [
  "gstd",
  "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
 ]
 
 [[package]]

--- a/escrow/Cargo.toml
+++ b/escrow/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Gear Technologies"]
 
 [dependencies]
 gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
-codec = { package = "parity-scale-codec", "version" = "3", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.11", default-features = false }
 escrow-io = { path = "io" }
 ft-io = { path = "../fungible-token/io" }

--- a/escrow/Cargo.toml
+++ b/escrow/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Gear Technologies"]
 [dependencies]
 gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
 codec = { package = "parity-scale-codec", "version" = "3", default-features = false, features = ["derive"] }
+primitive-types = { version = "0.11", default-features = false }
 escrow-io = { path = "io" }
 ft-io = { path = "../fungible-token/io" }
 

--- a/escrow/io/Cargo.toml
+++ b/escrow/io/Cargo.toml
@@ -8,3 +8,5 @@ authors = ["Gear Technologies"]
 [dependencies]
 gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+primitive-types = { version = "0.11", default-features = false, features = ["scale-info"] }
+scale-info = { version = "2", default-features = false, features = ["derive"] }

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -3,10 +3,12 @@
 use gstd::{prelude::*, ActorId};
 use primitive_types::U256;
 
+/// Escrow account ID.
 pub type AccountId = U256;
 
 #[derive(Decode, Encode, TypeInfo)]
 pub struct InitEscrow {
+    /// Address of a fungible token program.
     pub ft_program_id: ActorId,
 }
 

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -3,8 +3,8 @@
 use gstd::{prelude::*, ActorId};
 use primitive_types::U256;
 
-/// Escrow account ID.
-pub type AccountId = U256;
+/// Escrow wallet ID.
+pub type WalletId = U256;
 
 #[derive(Decode, Encode, TypeInfo)]
 pub struct InitEscrow {
@@ -19,10 +19,10 @@ pub enum EscrowAction {
         seller: ActorId,
         amount: u128,
     },
-    Deposit(AccountId),
-    Confirm(AccountId),
-    Refund(AccountId),
-    Cancel(AccountId),
+    Deposit(WalletId),
+    Confirm(WalletId),
+    Refund(WalletId),
+    Cancel(WalletId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]
@@ -44,29 +44,29 @@ pub enum EscrowEvent {
         buyer: ActorId,
         amount: u128,
     },
-    Created(AccountId),
+    Created(WalletId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]
 pub enum EscrowState {
-    GetInfo(AccountId),
+    GetInfo(WalletId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]
 pub enum EscrowStateReply {
-    Info(Account),
+    Info(Wallet),
 }
 
 #[derive(Decode, Encode, TypeInfo, Clone, Copy)]
-pub struct Account {
+pub struct Wallet {
     pub buyer: ActorId,
     pub seller: ActorId,
-    pub state: AccountState,
+    pub state: WalletState,
     pub amount: u128,
 }
 
 #[derive(Decode, Encode, TypeInfo, PartialEq, Clone, Copy)]
-pub enum AccountState {
+pub enum WalletState {
     AwaitingDeposit,
     AwaitingConfirmation,
     Closed,

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -3,6 +3,8 @@
 use gstd::{prelude::*, ActorId};
 use primitive_types::U256;
 
+pub type AccountId = U256;
+
 #[derive(Decode, Encode, TypeInfo)]
 pub struct InitEscrow {
     pub ft_program_id: ActorId,
@@ -15,10 +17,10 @@ pub enum EscrowAction {
         seller: ActorId,
         amount: u128,
     },
-    Deposit(U256),
-    Confirm(U256),
-    Refund(U256),
-    Cancel(U256),
+    Deposit(AccountId),
+    Confirm(AccountId),
+    Refund(AccountId),
+    Cancel(AccountId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]
@@ -40,12 +42,12 @@ pub enum EscrowEvent {
         buyer: ActorId,
         amount: u128,
     },
-    Created(U256),
+    Created(AccountId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]
 pub enum EscrowState {
-    GetInfo(U256),
+    GetInfo(AccountId),
 }
 
 #[derive(Decode, Encode, TypeInfo)]

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -42,3 +42,28 @@ pub enum EscrowEvent {
     },
     Created(U256),
 }
+
+#[derive(Decode, Encode, TypeInfo)]
+pub enum EscrowState {
+    GetInfo(U256),
+}
+
+#[derive(Decode, Encode, TypeInfo)]
+pub enum EscrowStateReply {
+    Info(Account),
+}
+
+#[derive(Decode, Encode, TypeInfo, Clone, Copy)]
+pub struct Account {
+    pub buyer: ActorId,
+    pub seller: ActorId,
+    pub state: AccountState,
+    pub amount: u128,
+}
+
+#[derive(Decode, Encode, TypeInfo, PartialEq, Clone, Copy)]
+pub enum AccountState {
+    AwaitingDeposit,
+    AwaitingConfirmation,
+    Closed,
+}

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Wallet {
     pub amount: u128,
 }
 
-#[derive(Decode, Encode, TypeInfo, PartialEq, Clone, Copy)]
+#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, Copy)]
 pub enum WalletState {
     AwaitingDeposit,
     AwaitingConfirmation,

--- a/escrow/io/src/lib.rs
+++ b/escrow/io/src/lib.rs
@@ -1,34 +1,27 @@
 #![no_std]
 
 use gstd::{prelude::*, ActorId};
+use primitive_types::U256;
 
-#[derive(Decode, Encode)]
+#[derive(Decode, Encode, TypeInfo)]
 pub struct InitEscrow {
     pub ft_program_id: ActorId,
 }
 
-#[derive(Decode, Encode)]
+#[derive(Decode, Encode, TypeInfo)]
 pub enum EscrowAction {
     Create {
         buyer: ActorId,
         seller: ActorId,
         amount: u128,
     },
-    Deposit {
-        contract_id: u128,
-    },
-    Confirm {
-        contract_id: u128,
-    },
-    Refund {
-        contract_id: u128,
-    },
-    Cancel {
-        contract_id: u128,
-    },
+    Deposit(U256),
+    Confirm(U256),
+    Refund(U256),
+    Cancel(U256),
 }
 
-#[derive(Decode, Encode)]
+#[derive(Decode, Encode, TypeInfo)]
 pub enum EscrowEvent {
     Cancelled {
         buyer: ActorId,
@@ -47,7 +40,5 @@ pub enum EscrowEvent {
         buyer: ActorId,
         amount: u128,
     },
-    Created {
-        contract_id: u128,
-    },
+    Created(U256),
 }

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -23,7 +23,7 @@ fn get(accounts: &mut BTreeMap<U256, Account>, account_id: U256) -> &mut Account
     if let Some(account) = accounts.get_mut(&account_id) {
         account
     } else {
-        panic!("An account with the {account_id} ID doesn't exist");
+        panic!("Account with the {account_id} ID doesn't exist");
     }
 }
 
@@ -46,7 +46,7 @@ impl Escrow {
     /// * `amount`: an amount of tokens.
     fn create(&mut self, buyer: ActorId, seller: ActorId, amount: u128) {
         if msg::source() != buyer && msg::source() != seller {
-            panic!("msg::source() must be a buyer or seller to create an escrow account");
+            panic!("msg::source() must be a buyer or seller to create the escrow account");
         }
 
         let account_id = self.id_nonce;
@@ -78,11 +78,11 @@ impl Escrow {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer {
-            panic!("msg::source() must a buyer saved in an account to make a deposit");
+            panic!("msg::source() must be a buyer saved in the account to make a deposit");
         }
 
         if account.state != AccountState::AwaitingDeposit {
-            panic!("Account can't take deposit if it's paid or closed");
+            panic!("Paid or closed account can't take a deposit");
         }
 
         transfer_tokens(
@@ -119,11 +119,11 @@ impl Escrow {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer {
-            panic!("msg::source() must a buyer saved in an account to confirm it");
+            panic!("msg::source() must a buyer saved in the account to confirm it");
         }
 
         if account.state != AccountState::AwaitingConfirmation {
-            panic!("Account can't be confirmed if it's not paid or closed");
+            panic!("Unpaid or closed account can't be confirmed");
         }
 
         transfer_tokens(
@@ -161,11 +161,11 @@ impl Escrow {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.seller {
-            panic!("msg::source() must be a seller saved in an account to refund");
+            panic!("msg::source() must be a seller saved in the account to refund");
         }
 
         if account.state != AccountState::AwaitingConfirmation {
-            panic!("Account can't be refunded if it's not paid or closed");
+            panic!("Unpaid or closed account can't be refunded");
         }
 
         transfer_tokens(
@@ -201,11 +201,11 @@ impl Escrow {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer && msg::source() != account.seller {
-            panic!("msg::source() must be a buyer or seller saved in an account to cancel it");
+            panic!("msg::source() must be a buyer or seller saved in the account to cancel it");
         }
 
         if account.state != AccountState::AwaitingDeposit {
-            panic!("Account can't be canceled if it's paid or closed");
+            panic!("Paid or closed account can't be canceled");
         }
 
         account.state = AccountState::Closed;
@@ -267,6 +267,7 @@ pub extern "C" fn meta_state() -> *mut [i32; 2] {
 
 gstd::metadata! {
     title: "Escrow",
+
     init:
         input: InitEscrow,
     handle:

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -19,7 +19,7 @@ fn transfer_tokens(
     msg::send_and_wait_for_reply(ft_program_id, FTAction::Transfer { from, to, amount }, 0).unwrap()
 }
 
-fn get(accounts: &mut BTreeMap<U256, Account>, account_id: U256) -> &mut Account {
+fn get(accounts: &mut BTreeMap<AccountId, Account>, account_id: AccountId) -> &mut Account {
     if let Some(account) = accounts.get_mut(&account_id) {
         account
     } else {
@@ -30,7 +30,7 @@ fn get(accounts: &mut BTreeMap<U256, Account>, account_id: U256) -> &mut Account
 #[derive(Default)]
 struct Escrow {
     ft_program_id: ActorId,
-    accounts: BTreeMap<U256, Account>,
+    accounts: BTreeMap<AccountId, Account>,
     id_nonce: U256,
 }
 
@@ -74,7 +74,7 @@ impl Escrow {
     ///
     /// Arguments:
     /// * `account_id`: an account ID.
-    async fn deposit(&mut self, account_id: U256) {
+    async fn deposit(&mut self, account_id: AccountId) {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer {
@@ -115,7 +115,7 @@ impl Escrow {
     ///
     /// Arguments:
     /// * `account_id`: an account ID.
-    async fn confirm(&mut self, account_id: U256) {
+    async fn confirm(&mut self, account_id: AccountId) {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer {
@@ -157,7 +157,7 @@ impl Escrow {
     ///
     /// Arguments:
     /// * `account_id`: an account ID.
-    async fn refund(&mut self, account_id: U256) {
+    async fn refund(&mut self, account_id: AccountId) {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.seller {
@@ -197,7 +197,7 @@ impl Escrow {
     ///
     /// Arguments:
     /// * `account_id`: an account ID.
-    async fn cancel(&mut self, account_id: U256) {
+    async fn cancel(&mut self, account_id: AccountId) {
         let account = get(&mut self.accounts, account_id);
 
         if msg::source() != account.buyer && msg::source() != account.seller {

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -8,9 +8,7 @@ use gstd::{
     prelude::*,
     ActorId,
 };
-<<<<<<< HEAD
 use primitive_types::U256;
-=======
 
 #[derive(PartialEq, Eq)]
 enum State {
@@ -18,7 +16,6 @@ enum State {
     AwaitingConfirmation,
     Completed,
 }
->>>>>>> master
 
 fn transfer_tokens(
     ft_program_id: ActorId,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -10,13 +10,6 @@ use gstd::{
 };
 use primitive_types::U256;
 
-#[derive(PartialEq, Eq)]
-enum State {
-    AwaitingDeposit,
-    AwaitingConfirmation,
-    Completed,
-}
-
 fn transfer_tokens(
     ft_program_id: ActorId,
     from: ActorId,

--- a/escrow/tests/cancel.rs
+++ b/escrow/tests/cancel.rs
@@ -8,7 +8,7 @@ fn cancel_paid() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -16,10 +16,10 @@ fn cancel_paid() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because a buyer/seller tries to cancel a paid contract
-    cancel_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    cancel_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because a buyer/seller tries to cancel a paid contract.
+    fail::cancel(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn foreign_user_cancel() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -37,8 +37,8 @@ fn foreign_user_cancel() {
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not a buyer/seller saved in a contract tries to cancel
-    cancel_fail(&escrow_program, CONTRACT[0], FOREIGN_USER);
+    // Should fail because not a buyer/seller saved in a contract tries to cancel.
+    fail::cancel(&escrow_program, CONTRACT[0], FOREIGN_USER);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn interact_after_cancel() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -56,7 +56,7 @@ fn interact_after_cancel() {
         SELLER[0],
         AMOUNT[0],
     );
-    cancel(
+    check::cancel(
         &escrow_program,
         CONTRACT[0],
         BUYER[0],
@@ -65,9 +65,9 @@ fn interact_after_cancel() {
         AMOUNT[0],
     );
 
-    // All of this should fail because nobody can interact with a contract after cancel
-    deposit_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    refund_fail(&escrow_program, CONTRACT[0], SELLER[0]);
-    confirm_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    cancel_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with a contract after cancel.
+    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
+    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
 }

--- a/escrow/tests/cancel.rs
+++ b/escrow/tests/cancel.rs
@@ -10,16 +10,16 @@ fn cancel_paid() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because the buyer/seller tries to close the paid account.
-    fail::cancel(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    // Should fail because the buyer/seller tries to cancel the deal with the paid wallet.
+    fail::cancel(&escrow_program, WALLET[0], BUYER[0]);
+    fail::cancel(&escrow_program, WALLET[0], SELLER[0]);
 }
 
 #[test]
@@ -31,14 +31,14 @@ fn foreign_user_cancel() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not the buyer/seller saved in the account tries to close it.
-    fail::cancel(&escrow_program, ACCOUNT[0], FOREIGN_USER);
+    // Should fail because not the buyer/seller for this wallet tries to cancel the deal and close the wallet.
+    fail::cancel(&escrow_program, WALLET[0], FOREIGN_USER);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn interact_after_cancel() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
@@ -58,16 +58,16 @@ fn interact_after_cancel() {
     );
     check::cancel(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         BUYER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
 
-    // All of this should fail because nobody can interact with a closed account.
-    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
-    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with a closed wallet.
+    fail::deposit(&escrow_program, WALLET[0], BUYER[0]);
+    fail::refund(&escrow_program, WALLET[0], SELLER[0]);
+    fail::confirm(&escrow_program, WALLET[0], BUYER[0]);
+    fail::cancel(&escrow_program, WALLET[0], SELLER[0]);
 }

--- a/escrow/tests/cancel.rs
+++ b/escrow/tests/cancel.rs
@@ -5,52 +5,52 @@ use utils::*;
 fn cancel_paid() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because a buyer/seller tries to cancel a paid contract.
-    fail::cancel(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because the buyer/seller tries to close the paid account.
+    fail::cancel(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
 }
 
 #[test]
 fn foreign_user_cancel() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not a buyer/seller saved in a contract tries to cancel.
-    fail::cancel(&escrow_program, CONTRACT[0], FOREIGN_USER);
+    // Should fail because not the buyer/seller saved in the account tries to close it.
+    fail::cancel(&escrow_program, ACCOUNT[0], FOREIGN_USER);
 }
 
 #[test]
 fn interact_after_cancel() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
@@ -58,16 +58,16 @@ fn interact_after_cancel() {
     );
     check::cancel(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         BUYER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
 
-    // All of this should fail because nobody can interact with a contract after cancel.
-    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
-    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with a closed account.
+    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
+    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
 }

--- a/escrow/tests/confirm.rs
+++ b/escrow/tests/confirm.rs
@@ -8,7 +8,7 @@ fn not_buyer_confirm() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -16,11 +16,11 @@ fn not_buyer_confirm() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not a buyer saved in a contract tries to confirm
-    confirm_fail(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    confirm_fail(&escrow_program, CONTRACT[0], BUYER[1]);
-    confirm_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not a buyer saved in a contract tries to confirm.
+    fail::confirm(&escrow_program, CONTRACT[0], FOREIGN_USER);
+    fail::confirm(&escrow_program, CONTRACT[0], BUYER[1]);
+    fail::confirm(&escrow_program, CONTRACT[0], SELLER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -31,7 +31,7 @@ fn double_confirm() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -39,10 +39,10 @@ fn double_confirm() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    // Should fail because a buyer tries to confirm twice
-    confirm_fail(&escrow_program, CONTRACT[0], BUYER[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    // Should fail because a buyer tries to confirm twice.
+    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], AMOUNT[0]);
 }
 
@@ -53,7 +53,7 @@ fn confirm_before_deposit() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -61,8 +61,8 @@ fn confirm_before_deposit() {
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a buyer tries to confirm before making a deposit
-    confirm_fail(&escrow_program, CONTRACT[0], BUYER[0]);
+    // Should fail because a buyer tries to confirm before making a deposit.
+    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -73,7 +73,7 @@ fn interact_after_confirm() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -81,12 +81,12 @@ fn interact_after_confirm() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
 
-    // All of this should fail because nobody can interact with a contract after confirm
-    deposit_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    refund_fail(&escrow_program, CONTRACT[0], SELLER[0]);
-    confirm_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    cancel_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with a contract after confirm.
+    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
+    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
 }

--- a/escrow/tests/confirm.rs
+++ b/escrow/tests/confirm.rs
@@ -10,17 +10,17 @@ fn not_buyer_confirm() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not the buyer saved in the account tries to confirm it.
-    fail::confirm(&escrow_program, ACCOUNT[0], FOREIGN_USER);
-    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[1]);
-    fail::confirm(&escrow_program, ACCOUNT[0], SELLER[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not the buyer for this wallet tries to confirm the deal.
+    fail::confirm(&escrow_program, WALLET[0], FOREIGN_USER);
+    fail::confirm(&escrow_program, WALLET[0], BUYER[1]);
+    fail::confirm(&escrow_program, WALLET[0], SELLER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -33,16 +33,16 @@ fn double_confirm() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    // Should fail because the buyer tries to confirm the account twice.
-    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, WALLET[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    // Should fail because the buyer tries to confirm the deal twice.
+    fail::confirm(&escrow_program, WALLET[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], AMOUNT[0]);
 }
 
@@ -55,14 +55,14 @@ fn confirm_before_deposit() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because the buyer tries to confirm the account before making a deposit.
-    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
+    // Should fail because the buyer tries to confirm the deal before depositing.
+    fail::confirm(&escrow_program, WALLET[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -75,18 +75,18 @@ fn interact_after_confirm() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, WALLET[0], BUYER[0], SELLER[0], AMOUNT[0]);
 
-    // All of this should fail because nobody can interact with an account after confirming it.
-    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
-    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with a wallet after confirming a deal.
+    fail::deposit(&escrow_program, WALLET[0], BUYER[0]);
+    fail::refund(&escrow_program, WALLET[0], SELLER[0]);
+    fail::confirm(&escrow_program, WALLET[0], BUYER[0]);
+    fail::cancel(&escrow_program, WALLET[0], SELLER[0]);
 }

--- a/escrow/tests/confirm.rs
+++ b/escrow/tests/confirm.rs
@@ -5,22 +5,22 @@ use utils::*;
 fn not_buyer_confirm() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not a buyer saved in a contract tries to confirm.
-    fail::confirm(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    fail::confirm(&escrow_program, CONTRACT[0], BUYER[1]);
-    fail::confirm(&escrow_program, CONTRACT[0], SELLER[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not the buyer saved in the account tries to confirm it.
+    fail::confirm(&escrow_program, ACCOUNT[0], FOREIGN_USER);
+    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[1]);
+    fail::confirm(&escrow_program, ACCOUNT[0], SELLER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -28,21 +28,21 @@ fn not_buyer_confirm() {
 fn double_confirm() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    // Should fail because a buyer tries to confirm twice.
-    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    // Should fail because the buyer tries to confirm the account twice.
+    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], AMOUNT[0]);
 }
 
@@ -50,19 +50,19 @@ fn double_confirm() {
 fn confirm_before_deposit() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a buyer tries to confirm before making a deposit.
-    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
+    // Should fail because the buyer tries to confirm the account before making a deposit.
+    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
     check_balance(&ft_program, SELLER[0], 0);
 }
 
@@ -70,23 +70,23 @@ fn confirm_before_deposit() {
 fn interact_after_confirm() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
 
-    // All of this should fail because nobody can interact with a contract after confirm.
-    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
-    fail::confirm(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::cancel(&escrow_program, CONTRACT[0], SELLER[0]);
+    // All of this should fail because nobody can interact with an account after confirming it.
+    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
+    fail::confirm(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::cancel(&escrow_program, ACCOUNT[0], SELLER[0]);
 }

--- a/escrow/tests/create.rs
+++ b/escrow/tests/create.rs
@@ -6,8 +6,8 @@ fn foreign_user_create() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    // Should fail because not a buyer/seller who will be saved in a contract tries to create
-    create_fail(
+    // Should fail because not a buyer/seller who will be saved in a contract tries to create.
+    fail::create(
         &escrow_program,
         FOREIGN_USER,
         BUYER[0],

--- a/escrow/tests/create.rs
+++ b/escrow/tests/create.rs
@@ -6,7 +6,7 @@ fn foreign_user_create() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    // Should fail because not a buyer/seller who will be saved in a contract tries to create.
+    // Should fail because not a buyer/seller who will be saved in the account tries to create it.
     fail::create(
         &escrow_program,
         FOREIGN_USER,

--- a/escrow/tests/create.rs
+++ b/escrow/tests/create.rs
@@ -6,7 +6,7 @@ fn foreign_user_create() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    // Should fail because not a buyer/seller who will be saved in the account tries to create it.
+    // Should fail because not a future buyer/seller for this wallet tries to create it.
     fail::create(
         &escrow_program,
         FOREIGN_USER,

--- a/escrow/tests/deposit.rs
+++ b/escrow/tests/deposit.rs
@@ -6,39 +6,39 @@ fn not_enougn_tokens() {
     let system = init_system();
 
     let escrow_program = init_escrow(&system);
-    let _ft_program = init_fungible_tokens(&system);
+    init_ft(&system);
 
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a buyer doesn't have enough tokens to deposit.
-    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
+    // Should fail because the buyer doesn't have enough tokens to deposit.
+    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
 }
 
 #[test]
 fn double_deposit() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
-    // Purposely make it possible for a buyer to pay twice.
+    // Purposely make it possible for the buyer to pay twice.
     mint(&ft_program, BUYER[0], AMOUNT[0] * 2);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because a buyer tries to make a deposit twice.
-    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because the buyer tries to make the deposit twice.
+    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 }
 
@@ -49,14 +49,14 @@ fn not_buyer_deposit() {
 
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not a buyer saved in contract tries to make a deposit.
-    fail::deposit(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    fail::deposit(&escrow_program, CONTRACT[0], BUYER[1]);
-    fail::deposit(&escrow_program, CONTRACT[0], SELLER[0]);
+    // Should fail because not a buyer saved in the account tries to make the deposit.
+    fail::deposit(&escrow_program, ACCOUNT[0], FOREIGN_USER);
+    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[1]);
+    fail::deposit(&escrow_program, ACCOUNT[0], SELLER[0]);
 }

--- a/escrow/tests/deposit.rs
+++ b/escrow/tests/deposit.rs
@@ -8,7 +8,7 @@ fn not_enougn_tokens() {
     let escrow_program = init_escrow(&system);
     let _ft_program = init_fungible_tokens(&system);
 
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -16,8 +16,8 @@ fn not_enougn_tokens() {
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a buyer doesn't have enought tokens to deposit
-    deposit_fail(&escrow_program, CONTRACT[0], BUYER[0]);
+    // Should fail because a buyer doesn't have enough tokens to deposit.
+    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
 }
 
 #[test]
@@ -26,9 +26,9 @@ fn double_deposit() {
     let escrow_program = init_escrow(&system);
     let ft_program = init_fungible_tokens(&system);
 
-    // Purposely make it possible for a buyer to pay twice
+    // Purposely make it possible for a buyer to pay twice.
     mint(&ft_program, BUYER[0], AMOUNT[0] * 2);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -36,9 +36,9 @@ fn double_deposit() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because a buyer tries to make a deposit twice
-    deposit_fail(&escrow_program, CONTRACT[0], BUYER[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because a buyer tries to make a deposit twice.
+    fail::deposit(&escrow_program, CONTRACT[0], BUYER[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 }
 
@@ -47,7 +47,7 @@ fn not_buyer_deposit() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -55,8 +55,8 @@ fn not_buyer_deposit() {
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not a buyer saved in contract tries to make a deposit
-    deposit_fail(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    deposit_fail(&escrow_program, CONTRACT[0], BUYER[1]);
-    deposit_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    // Should fail because not a buyer saved in contract tries to make a deposit.
+    fail::deposit(&escrow_program, CONTRACT[0], FOREIGN_USER);
+    fail::deposit(&escrow_program, CONTRACT[0], BUYER[1]);
+    fail::deposit(&escrow_program, CONTRACT[0], SELLER[0]);
 }

--- a/escrow/tests/deposit.rs
+++ b/escrow/tests/deposit.rs
@@ -10,14 +10,14 @@ fn not_enougn_tokens() {
 
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
     // Should fail because the buyer doesn't have enough tokens to deposit.
-    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::deposit(&escrow_program, WALLET[0], BUYER[0]);
 }
 
 #[test]
@@ -30,15 +30,15 @@ fn double_deposit() {
     mint(&ft_program, BUYER[0], AMOUNT[0] * 2);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because the buyer tries to make the deposit twice.
-    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    // Should fail because the buyer tries to deposit twice.
+    fail::deposit(&escrow_program, WALLET[0], BUYER[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 }
 
@@ -49,14 +49,14 @@ fn not_buyer_deposit() {
 
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because not a buyer saved in the account tries to make the deposit.
-    fail::deposit(&escrow_program, ACCOUNT[0], FOREIGN_USER);
-    fail::deposit(&escrow_program, ACCOUNT[0], BUYER[1]);
-    fail::deposit(&escrow_program, ACCOUNT[0], SELLER[0]);
+    // Should fail because not a buyer for this wallet tries to deposit.
+    fail::deposit(&escrow_program, WALLET[0], FOREIGN_USER);
+    fail::deposit(&escrow_program, WALLET[0], BUYER[1]);
+    fail::deposit(&escrow_program, WALLET[0], SELLER[0]);
 }

--- a/escrow/tests/other.rs
+++ b/escrow/tests/other.rs
@@ -14,7 +14,7 @@ fn two_different_escrows() {
 
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
@@ -22,18 +22,18 @@ fn two_different_escrows() {
     );
     check::create(
         &escrow_program,
-        ACCOUNT[1],
+        WALLET[1],
         SELLER[1],
         BUYER[1],
         SELLER[1],
         AMOUNT[1],
     );
 
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    check::deposit(&escrow_program, ACCOUNT[1], BUYER[1], AMOUNT[1]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, WALLET[1], BUYER[1], AMOUNT[1]);
 
-    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, ACCOUNT[1], BUYER[1], SELLER[1], AMOUNT[1]);
+    check::confirm(&escrow_program, WALLET[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, WALLET[1], BUYER[1], SELLER[1], AMOUNT[1]);
 
     check_balance(&ft_program, BUYER[0], AMOUNT_REMAINDER);
     check_balance(&ft_program, BUYER[1], AMOUNT_REMAINDER);
@@ -51,30 +51,30 @@ fn reuse_after_refund() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
 
-    check::refund(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::refund(&escrow_program, WALLET[0], BUYER[0], SELLER[0], AMOUNT[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, WALLET[0], BUYER[0], SELLER[0], AMOUNT[0]);
 }
 
 #[test]
-fn interact_with_non_existend_account() {
-    const NONEXISTEND_CONTRACT: u128 = 999999;
+fn interact_with_non_existend_wallet() {
+    const NONEXISTEND_WALLET: u128 = 999999;
 
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    fail::deposit(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    fail::cancel(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    fail::refund(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    fail::confirm(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
+    fail::deposit(&escrow_program, NONEXISTEND_WALLET, BUYER[0]);
+    fail::cancel(&escrow_program, NONEXISTEND_WALLET, BUYER[0]);
+    fail::refund(&escrow_program, NONEXISTEND_WALLET, BUYER[0]);
+    fail::confirm(&escrow_program, NONEXISTEND_WALLET, BUYER[0]);
 }

--- a/escrow/tests/other.rs
+++ b/escrow/tests/other.rs
@@ -12,7 +12,7 @@ fn two_different_escrows() {
     mint(&ft_program, BUYER[0], AMOUNT[0] + AMOUNT_REMAINDER);
     mint(&ft_program, BUYER[1], AMOUNT[1] + AMOUNT_REMAINDER);
 
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -20,7 +20,7 @@ fn two_different_escrows() {
         SELLER[0],
         AMOUNT[0],
     );
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[1],
         SELLER[1],
@@ -29,11 +29,11 @@ fn two_different_escrows() {
         AMOUNT[1],
     );
 
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    deposit(&escrow_program, CONTRACT[1], BUYER[1], AMOUNT[1]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, CONTRACT[1], BUYER[1], AMOUNT[1]);
 
-    confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    confirm(&escrow_program, CONTRACT[1], BUYER[1], SELLER[1], AMOUNT[1]);
+    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, CONTRACT[1], BUYER[1], SELLER[1], AMOUNT[1]);
 
     check_balance(&ft_program, BUYER[0], AMOUNT_REMAINDER);
     check_balance(&ft_program, BUYER[1], AMOUNT_REMAINDER);
@@ -49,7 +49,7 @@ fn reuse_after_refund() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -57,13 +57,13 @@ fn reuse_after_refund() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
 
-    refund(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::refund(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
 }
 
 #[test]
@@ -73,8 +73,8 @@ fn interact_with_non_existend_contract() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
 
-    deposit_fail(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    cancel_fail(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    refund_fail(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
-    confirm_fail(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
+    fail::deposit(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
+    fail::cancel(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
+    fail::refund(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
+    fail::confirm(&escrow_program, NONEXISTEND_CONTRACT, BUYER[0]);
 }

--- a/escrow/tests/other.rs
+++ b/escrow/tests/other.rs
@@ -7,14 +7,14 @@ fn two_different_escrows() {
 
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0] + AMOUNT_REMAINDER);
     mint(&ft_program, BUYER[1], AMOUNT[1] + AMOUNT_REMAINDER);
 
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
@@ -22,18 +22,18 @@ fn two_different_escrows() {
     );
     check::create(
         &escrow_program,
-        CONTRACT[1],
+        ACCOUNT[1],
         SELLER[1],
         BUYER[1],
         SELLER[1],
         AMOUNT[1],
     );
 
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    check::deposit(&escrow_program, CONTRACT[1], BUYER[1], AMOUNT[1]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, ACCOUNT[1], BUYER[1], AMOUNT[1]);
 
-    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, CONTRACT[1], BUYER[1], SELLER[1], AMOUNT[1]);
+    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, ACCOUNT[1], BUYER[1], SELLER[1], AMOUNT[1]);
 
     check_balance(&ft_program, BUYER[0], AMOUNT_REMAINDER);
     check_balance(&ft_program, BUYER[1], AMOUNT_REMAINDER);
@@ -46,28 +46,28 @@ fn two_different_escrows() {
 fn reuse_after_refund() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
 
-    check::refund(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::refund(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
     check_balance(&ft_program, BUYER[0], AMOUNT[0]);
 
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    check::confirm(&escrow_program, CONTRACT[0], BUYER[0], SELLER[0], AMOUNT[0]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    check::confirm(&escrow_program, ACCOUNT[0], BUYER[0], SELLER[0], AMOUNT[0]);
 }
 
 #[test]
-fn interact_with_non_existend_contract() {
+fn interact_with_non_existend_account() {
     const NONEXISTEND_CONTRACT: u128 = 999999;
 
     let system = init_system();

--- a/escrow/tests/refund.rs
+++ b/escrow/tests/refund.rs
@@ -8,7 +8,7 @@ fn refund_not_paid() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -16,8 +16,8 @@ fn refund_not_paid() {
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a seller tries to refund an unpaid contract
-    refund_fail(&escrow_program, CONTRACT[0], SELLER[0]);
+    // Should fail because a seller tries to refund an unpaid contract.
+    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn not_seller_refund() {
     let ft_program = init_fungible_tokens(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
-    create(
+    check::create(
         &escrow_program,
         CONTRACT[0],
         SELLER[0],
@@ -35,9 +35,9 @@ fn not_seller_refund() {
         SELLER[0],
         AMOUNT[0],
     );
-    deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not a seller saved in a contract tries to refund
-    refund_fail(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    refund_fail(&escrow_program, CONTRACT[0], BUYER[0]);
-    refund_fail(&escrow_program, CONTRACT[0], SELLER[1]);
+    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not a seller saved in a contract tries to refund.
+    fail::refund(&escrow_program, CONTRACT[0], FOREIGN_USER);
+    fail::refund(&escrow_program, CONTRACT[0], BUYER[0]);
+    fail::refund(&escrow_program, CONTRACT[0], SELLER[1]);
 }

--- a/escrow/tests/refund.rs
+++ b/escrow/tests/refund.rs
@@ -5,39 +5,39 @@ use utils::*;
 fn refund_not_paid() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because a seller tries to refund an unpaid contract.
-    fail::refund(&escrow_program, CONTRACT[0], SELLER[0]);
+    // Should fail because the seller tries to refund tokens from the unpaid account.
+    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
 }
 
 #[test]
 fn not_seller_refund() {
     let system = init_system();
     let escrow_program = init_escrow(&system);
-    let ft_program = init_fungible_tokens(&system);
+    let ft_program = init_ft(&system);
 
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        CONTRACT[0],
+        ACCOUNT[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, CONTRACT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not a seller saved in a contract tries to refund.
-    fail::refund(&escrow_program, CONTRACT[0], FOREIGN_USER);
-    fail::refund(&escrow_program, CONTRACT[0], BUYER[0]);
-    fail::refund(&escrow_program, CONTRACT[0], SELLER[1]);
+    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not the seller saved in the account tries to refund.
+    fail::refund(&escrow_program, ACCOUNT[0], FOREIGN_USER);
+    fail::refund(&escrow_program, ACCOUNT[0], BUYER[0]);
+    fail::refund(&escrow_program, ACCOUNT[0], SELLER[1]);
 }

--- a/escrow/tests/refund.rs
+++ b/escrow/tests/refund.rs
@@ -10,14 +10,14 @@ fn refund_not_paid() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    // Should fail because the seller tries to refund tokens from the unpaid account.
-    fail::refund(&escrow_program, ACCOUNT[0], SELLER[0]);
+    // Should fail because the seller tries to refund tokens from the unpaid wallet.
+    fail::refund(&escrow_program, WALLET[0], SELLER[0]);
 }
 
 #[test]
@@ -29,15 +29,15 @@ fn not_seller_refund() {
     mint(&ft_program, BUYER[0], AMOUNT[0]);
     check::create(
         &escrow_program,
-        ACCOUNT[0],
+        WALLET[0],
         SELLER[0],
         BUYER[0],
         SELLER[0],
         AMOUNT[0],
     );
-    check::deposit(&escrow_program, ACCOUNT[0], BUYER[0], AMOUNT[0]);
-    // Should fail because not the seller saved in the account tries to refund.
-    fail::refund(&escrow_program, ACCOUNT[0], FOREIGN_USER);
-    fail::refund(&escrow_program, ACCOUNT[0], BUYER[0]);
-    fail::refund(&escrow_program, ACCOUNT[0], SELLER[1]);
+    check::deposit(&escrow_program, WALLET[0], BUYER[0], AMOUNT[0]);
+    // Should fail because not the seller for this wallet tries to refund.
+    fail::refund(&escrow_program, WALLET[0], FOREIGN_USER);
+    fail::refund(&escrow_program, WALLET[0], BUYER[0]);
+    fail::refund(&escrow_program, WALLET[0], SELLER[1]);
 }

--- a/escrow/tests/utils/check.rs
+++ b/escrow/tests/utils/check.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn create(
     escrow_program: &Program,
-    contract_id: u128,
+    account_id: u128,
     from: u64,
     buyer: u64,
     seller: u64,
@@ -17,12 +17,12 @@ pub fn create(
                 amount,
             },
         )
-        .contains(&(from, EscrowEvent::Created(contract_id.into()).encode())));
+        .contains(&(from, EscrowEvent::Created(account_id.into()).encode())));
 }
 
-pub fn deposit(escrow_program: &Program, contract_id: u128, buyer: u64, amount: u128) {
+pub fn deposit(escrow_program: &Program, account_id: u128, buyer: u64, amount: u128) {
     assert!(escrow_program
-        .send(buyer, EscrowAction::Deposit(contract_id.into()))
+        .send(buyer, EscrowAction::Deposit(account_id.into()))
         .contains(&(
             buyer,
             EscrowEvent::Deposited {
@@ -33,9 +33,9 @@ pub fn deposit(escrow_program: &Program, contract_id: u128, buyer: u64, amount: 
         )));
 }
 
-pub fn confirm(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
+pub fn confirm(escrow_program: &Program, account_id: u128, buyer: u64, seller: u64, amount: u128) {
     assert!(escrow_program
-        .send(buyer, EscrowAction::Confirm(contract_id.into()))
+        .send(buyer, EscrowAction::Confirm(account_id.into()))
         .contains(&(
             buyer,
             EscrowEvent::Confirmed {
@@ -46,9 +46,9 @@ pub fn confirm(escrow_program: &Program, contract_id: u128, buyer: u64, seller: 
         )));
 }
 
-pub fn refund(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
+pub fn refund(escrow_program: &Program, account_id: u128, buyer: u64, seller: u64, amount: u128) {
     assert!(escrow_program
-        .send(seller, EscrowAction::Refund(contract_id.into()))
+        .send(seller, EscrowAction::Refund(account_id.into()))
         .contains(&(
             seller,
             EscrowEvent::Refunded {
@@ -61,14 +61,14 @@ pub fn refund(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u
 
 pub fn cancel(
     escrow_program: &Program,
-    contract_id: u128,
+    account_id: u128,
     from: u64,
     buyer: u64,
     seller: u64,
     amount: u128,
 ) {
     assert!(escrow_program
-        .send(from, EscrowAction::Cancel(contract_id.into()))
+        .send(from, EscrowAction::Cancel(account_id.into()))
         .contains(&(
             from,
             EscrowEvent::Cancelled {

--- a/escrow/tests/utils/check.rs
+++ b/escrow/tests/utils/check.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+pub fn create(
+    escrow_program: &Program,
+    contract_id: u128,
+    from: u64,
+    buyer: u64,
+    seller: u64,
+    amount: u128,
+) {
+    assert!(escrow_program
+        .send(
+            from,
+            EscrowAction::Create {
+                buyer: buyer.into(),
+                seller: seller.into(),
+                amount,
+            },
+        )
+        .contains(&(from, EscrowEvent::Created(contract_id.into()).encode())));
+}
+
+pub fn deposit(escrow_program: &Program, contract_id: u128, buyer: u64, amount: u128) {
+    assert!(escrow_program
+        .send(buyer, EscrowAction::Deposit(contract_id.into()))
+        .contains(&(
+            buyer,
+            EscrowEvent::Deposited {
+                buyer: buyer.into(),
+                amount,
+            }
+            .encode()
+        )));
+}
+
+pub fn confirm(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
+    assert!(escrow_program
+        .send(buyer, EscrowAction::Confirm(contract_id.into()))
+        .contains(&(
+            buyer,
+            EscrowEvent::Confirmed {
+                seller: seller.into(),
+                amount,
+            }
+            .encode()
+        )));
+}
+
+pub fn refund(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
+    assert!(escrow_program
+        .send(seller, EscrowAction::Refund(contract_id.into()))
+        .contains(&(
+            seller,
+            EscrowEvent::Refunded {
+                buyer: buyer.into(),
+                amount
+            }
+            .encode()
+        )));
+}
+
+pub fn cancel(
+    escrow_program: &Program,
+    contract_id: u128,
+    from: u64,
+    buyer: u64,
+    seller: u64,
+    amount: u128,
+) {
+    assert!(escrow_program
+        .send(from, EscrowAction::Cancel(contract_id.into()))
+        .contains(&(
+            from,
+            EscrowEvent::Cancelled {
+                buyer: buyer.into(),
+                seller: seller.into(),
+                amount
+            }
+            .encode()
+        )));
+}

--- a/escrow/tests/utils/check.rs
+++ b/escrow/tests/utils/check.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn create(
     escrow_program: &Program,
-    account_id: u128,
+    wallet_id: u128,
     from: u64,
     buyer: u64,
     seller: u64,
@@ -17,12 +17,12 @@ pub fn create(
                 amount,
             },
         )
-        .contains(&(from, EscrowEvent::Created(account_id.into()).encode())));
+        .contains(&(from, EscrowEvent::Created(wallet_id.into()).encode())));
 }
 
-pub fn deposit(escrow_program: &Program, account_id: u128, buyer: u64, amount: u128) {
+pub fn deposit(escrow_program: &Program, wallet_id: u128, buyer: u64, amount: u128) {
     assert!(escrow_program
-        .send(buyer, EscrowAction::Deposit(account_id.into()))
+        .send(buyer, EscrowAction::Deposit(wallet_id.into()))
         .contains(&(
             buyer,
             EscrowEvent::Deposited {
@@ -33,9 +33,9 @@ pub fn deposit(escrow_program: &Program, account_id: u128, buyer: u64, amount: u
         )));
 }
 
-pub fn confirm(escrow_program: &Program, account_id: u128, buyer: u64, seller: u64, amount: u128) {
+pub fn confirm(escrow_program: &Program, wallet_id: u128, buyer: u64, seller: u64, amount: u128) {
     assert!(escrow_program
-        .send(buyer, EscrowAction::Confirm(account_id.into()))
+        .send(buyer, EscrowAction::Confirm(wallet_id.into()))
         .contains(&(
             buyer,
             EscrowEvent::Confirmed {
@@ -46,9 +46,9 @@ pub fn confirm(escrow_program: &Program, account_id: u128, buyer: u64, seller: u
         )));
 }
 
-pub fn refund(escrow_program: &Program, account_id: u128, buyer: u64, seller: u64, amount: u128) {
+pub fn refund(escrow_program: &Program, wallet_id: u128, buyer: u64, seller: u64, amount: u128) {
     assert!(escrow_program
-        .send(seller, EscrowAction::Refund(account_id.into()))
+        .send(seller, EscrowAction::Refund(wallet_id.into()))
         .contains(&(
             seller,
             EscrowEvent::Refunded {
@@ -61,14 +61,14 @@ pub fn refund(escrow_program: &Program, account_id: u128, buyer: u64, seller: u6
 
 pub fn cancel(
     escrow_program: &Program,
-    account_id: u128,
+    wallet_id: u128,
     from: u64,
     buyer: u64,
     seller: u64,
     amount: u128,
 ) {
     assert!(escrow_program
-        .send(from, EscrowAction::Cancel(account_id.into()))
+        .send(from, EscrowAction::Cancel(wallet_id.into()))
         .contains(&(
             from,
             EscrowEvent::Cancelled {

--- a/escrow/tests/utils/fail.rs
+++ b/escrow/tests/utils/fail.rs
@@ -13,26 +13,26 @@ pub fn create(escrow_program: &Program, from: u64, buyer: u64, seller: u64, amou
         .main_failed());
 }
 
-pub fn deposit(escrow_program: &Program, account_id: u128, from: u64) {
+pub fn deposit(escrow_program: &Program, wallet_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Deposit(account_id.into()))
+        .send(from, EscrowAction::Deposit(wallet_id.into()))
         .main_failed());
 }
 
-pub fn confirm(escrow_program: &Program, account_id: u128, from: u64) {
+pub fn confirm(escrow_program: &Program, wallet_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Confirm(account_id.into()))
+        .send(from, EscrowAction::Confirm(wallet_id.into()))
         .main_failed());
 }
 
-pub fn refund(escrow_program: &Program, account_id: u128, from: u64) {
+pub fn refund(escrow_program: &Program, wallet_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Refund(account_id.into()))
+        .send(from, EscrowAction::Refund(wallet_id.into()))
         .main_failed());
 }
 
-pub fn cancel(escrow_program: &Program, account_id: u128, from: u64) {
+pub fn cancel(escrow_program: &Program, wallet_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Cancel(account_id.into()))
+        .send(from, EscrowAction::Cancel(wallet_id.into()))
         .main_failed());
 }

--- a/escrow/tests/utils/fail.rs
+++ b/escrow/tests/utils/fail.rs
@@ -13,26 +13,26 @@ pub fn create(escrow_program: &Program, from: u64, buyer: u64, seller: u64, amou
         .main_failed());
 }
 
-pub fn deposit(escrow_program: &Program, contract_id: u128, from: u64) {
+pub fn deposit(escrow_program: &Program, account_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Deposit(contract_id.into()))
+        .send(from, EscrowAction::Deposit(account_id.into()))
         .main_failed());
 }
 
-pub fn confirm(escrow_program: &Program, contract_id: u128, from: u64) {
+pub fn confirm(escrow_program: &Program, account_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Confirm(contract_id.into()))
+        .send(from, EscrowAction::Confirm(account_id.into()))
         .main_failed());
 }
 
-pub fn refund(escrow_program: &Program, contract_id: u128, from: u64) {
+pub fn refund(escrow_program: &Program, account_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Refund(contract_id.into()))
+        .send(from, EscrowAction::Refund(account_id.into()))
         .main_failed());
 }
 
-pub fn cancel(escrow_program: &Program, contract_id: u128, from: u64) {
+pub fn cancel(escrow_program: &Program, account_id: u128, from: u64) {
     assert!(escrow_program
-        .send(from, EscrowAction::Cancel(contract_id.into()))
+        .send(from, EscrowAction::Cancel(account_id.into()))
         .main_failed());
 }

--- a/escrow/tests/utils/fail.rs
+++ b/escrow/tests/utils/fail.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+pub fn create(escrow_program: &Program, from: u64, buyer: u64, seller: u64, amount: u128) {
+    assert!(escrow_program
+        .send(
+            from,
+            EscrowAction::Create {
+                buyer: buyer.into(),
+                seller: seller.into(),
+                amount,
+            },
+        )
+        .main_failed());
+}
+
+pub fn deposit(escrow_program: &Program, contract_id: u128, from: u64) {
+    assert!(escrow_program
+        .send(from, EscrowAction::Deposit(contract_id.into()))
+        .main_failed());
+}
+
+pub fn confirm(escrow_program: &Program, contract_id: u128, from: u64) {
+    assert!(escrow_program
+        .send(from, EscrowAction::Confirm(contract_id.into()))
+        .main_failed());
+}
+
+pub fn refund(escrow_program: &Program, contract_id: u128, from: u64) {
+    assert!(escrow_program
+        .send(from, EscrowAction::Refund(contract_id.into()))
+        .main_failed());
+}
+
+pub fn cancel(escrow_program: &Program, contract_id: u128, from: u64) {
+    assert!(escrow_program
+        .send(from, EscrowAction::Cancel(contract_id.into()))
+        .main_failed());
+}

--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -6,12 +6,12 @@ use gtest::{Program, System};
 pub mod check;
 pub mod fail;
 
-pub const FT: u64 = 2;
+pub const FT_PROGRAM_ID: u64 = 2;
 pub const FOREIGN_USER: u64 = 1337;
 pub const BUYER: [u64; 2] = [12, 34];
 pub const SELLER: [u64; 2] = [56, 78];
 pub const AMOUNT: [u128; 2] = [12345, 54321];
-pub const CONTRACT: [u128; 2] = [0, 1];
+pub const ACCOUNT: [u128; 2] = [0, 1];
 
 pub fn init_system() -> System {
     let system = System::new();
@@ -20,7 +20,7 @@ pub fn init_system() -> System {
     system
 }
 
-pub fn init_fungible_tokens(sys: &System) -> Program {
+pub fn init_ft(sys: &System) -> Program {
     let ft_program = Program::from_file(
         &sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
@@ -47,7 +47,7 @@ pub fn init_escrow(sys: &System) -> Program {
         .send(
             FOREIGN_USER,
             InitEscrow {
-                ft_program_id: FT.into(),
+                ft_program_id: FT_PROGRAM_ID.into(),
             },
         )
         .log()

--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -11,7 +11,7 @@ pub const FOREIGN_USER: u64 = 1337;
 pub const BUYER: [u64; 2] = [12, 34];
 pub const SELLER: [u64; 2] = [56, 78];
 pub const AMOUNT: [u128; 2] = [12345, 54321];
-pub const ACCOUNT: [u128; 2] = [0, 1];
+pub const WALLET: [u128; 2] = [0, 1];
 
 pub fn init_system() -> System {
     let system = System::new();

--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -1,8 +1,10 @@
-use escrow_io::*;
-use ft_io::*;
-use gstd::Encode;
-use gstd::String;
+use escrow_io::{EscrowAction, EscrowEvent, InitEscrow};
+use ft_io::{FTAction, FTEvent, InitConfig as InitFT};
+use gstd::prelude::*;
 use gtest::{Program, System};
+
+pub mod check;
+pub mod fail;
 
 pub const FT: u64 = 2;
 pub const FOREIGN_USER: u64 = 1337;
@@ -27,7 +29,7 @@ pub fn init_fungible_tokens(sys: &System) -> Program {
     assert!(ft_program
         .send(
             FOREIGN_USER,
-            InitConfig {
+            InitFT {
                 name: String::from("MyToken"),
                 symbol: String::from("MTK"),
             },
@@ -52,123 +54,6 @@ pub fn init_escrow(sys: &System) -> Program {
         .is_empty());
 
     escrow_program
-}
-
-pub fn create(
-    escrow_program: &Program,
-    contract_id: u128,
-    from: u64,
-    buyer: u64,
-    seller: u64,
-    amount: u128,
-) {
-    assert!(escrow_program
-        .send(
-            from,
-            EscrowAction::Create {
-                buyer: buyer.into(),
-                seller: seller.into(),
-                amount,
-            },
-        )
-        .contains(&(from, EscrowEvent::Created { contract_id }.encode())));
-}
-
-pub fn create_fail(escrow_program: &Program, from: u64, buyer: u64, seller: u64, amount: u128) {
-    assert!(escrow_program
-        .send(
-            from,
-            EscrowAction::Create {
-                buyer: buyer.into(),
-                seller: seller.into(),
-                amount,
-            },
-        )
-        .main_failed());
-}
-
-pub fn deposit(escrow_program: &Program, contract_id: u128, buyer: u64, amount: u128) {
-    assert!(escrow_program
-        .send(buyer, EscrowAction::Deposit { contract_id })
-        .contains(&(
-            buyer,
-            EscrowEvent::Deposited {
-                buyer: buyer.into(),
-                amount,
-            }
-            .encode()
-        )));
-}
-
-pub fn deposit_fail(escrow_program: &Program, contract_id: u128, from: u64) {
-    assert!(escrow_program
-        .send(from, EscrowAction::Deposit { contract_id })
-        .main_failed());
-}
-
-pub fn confirm(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
-    assert!(escrow_program
-        .send(buyer, EscrowAction::Confirm { contract_id })
-        .contains(&(
-            buyer,
-            EscrowEvent::Confirmed {
-                seller: seller.into(),
-                amount,
-            }
-            .encode()
-        )));
-}
-
-pub fn confirm_fail(escrow_program: &Program, contract_id: u128, from: u64) {
-    assert!(escrow_program
-        .send(from, EscrowAction::Confirm { contract_id })
-        .main_failed());
-}
-
-pub fn refund(escrow_program: &Program, contract_id: u128, buyer: u64, seller: u64, amount: u128) {
-    assert!(escrow_program
-        .send(seller, EscrowAction::Refund { contract_id })
-        .contains(&(
-            seller,
-            EscrowEvent::Refunded {
-                buyer: buyer.into(),
-                amount
-            }
-            .encode()
-        )));
-}
-
-pub fn refund_fail(escrow_program: &Program, contract_id: u128, from: u64) {
-    assert!(escrow_program
-        .send(from, EscrowAction::Refund { contract_id })
-        .main_failed());
-}
-
-pub fn cancel(
-    escrow_program: &Program,
-    contract_id: u128,
-    from: u64,
-    buyer: u64,
-    seller: u64,
-    amount: u128,
-) {
-    assert!(escrow_program
-        .send(from, EscrowAction::Cancel { contract_id })
-        .contains(&(
-            from,
-            EscrowEvent::Cancelled {
-                buyer: buyer.into(),
-                seller: seller.into(),
-                amount
-            }
-            .encode()
-        )));
-}
-
-pub fn cancel_fail(escrow_program: &Program, contract_id: u128, from: u64) {
-    assert!(escrow_program
-        .send(from, EscrowAction::Cancel { contract_id })
-        .main_failed());
 }
 
 pub fn check_balance(ft_program: &Program, from: u64, amount: u128) {


### PR DESCRIPTION
- Renames the escrow **contract** creation to the escrow ~~**account**~~ **wallet** creation to avoid confusion with the escrow contract itself.
- Reduces **Action** & **Event** enums by removing obvious `contract_id` field identifiers from them:
https://github.com/gear-tech/apps/blob/f21c37f832b356d823f1b9ee1b91e07769da4771/escrow/io/src/lib.rs#L17-L28
- Adds metadata & the `meta_state` function for reading escrow accounts info.
- Adds the type alias for an account ID and changes its type from `u128` to `U256` for greater capacity, like in the example implementation of NFT:
https://github.com/gear-tech/apps/blob/f21c37f832b356d823f1b9ee1b91e07769da4771/nft-example/src/lib.rs#L21 
- Rewrites `utils` for tests to make them more readable.
- Minor changes in docs/comments/panic messages.

Linked wiki article update: https://github.com/gear-tech/wiki/pull/174.