### PR TITLE
Enable clippy for all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fmt-check:
 
 linter:
 	@echo ──────────── Run linter ───────────────────────
-	@cargo +nightly clippy --workspace -- --no-deps -D warnings -A "clippy::missing_safety_doc"
+	@cargo +nightly clippy --all-targets -- --no-deps -D warnings -A "clippy::missing_safety_doc"
 
 pre-check: fmt-check linter check
 

--- a/concert/tests/utils.rs
+++ b/concert/tests/utils.rs
@@ -27,47 +27,41 @@ impl WasmProgram for MultiToken {
                 id,
                 amount,
                 meta: _,
-            } => {
-                return Ok(Some(
-                    MTKEvent::TransferSingle(TransferSingleReply {
-                        operator: 1.into(),
-                        from: ZERO_ID,
-                        to: account,
-                        id,
-                        amount,
-                    })
-                    .encode(),
-                ));
-            }
+            } => Ok(Some(
+                MTKEvent::TransferSingle(TransferSingleReply {
+                    operator: 1.into(),
+                    from: ZERO_ID,
+                    to: account,
+                    id,
+                    amount,
+                })
+                .encode(),
+            )),
             MTKAction::MintBatch {
                 account,
                 ids,
                 amounts,
                 meta: _,
-            } => {
-                return Ok(Some(
-                    MTKEvent::TransferBatch {
-                        operator: 1.into(),
-                        from: ZERO_ID,
-                        to: account,
-                        ids: ids.to_vec(),
-                        values: amounts.to_vec(),
-                    }
-                    .encode(),
-                ));
-            }
-            MTKAction::Burn { id, amount } => {
-                return Ok(Some(
-                    MTKEvent::TransferSingle(TransferSingleReply {
-                        operator: 1.into(),
-                        from: 1.into(),
-                        to: ZERO_ID,
-                        id,
-                        amount,
-                    })
-                    .encode(),
-                ));
-            }
+            } => Ok(Some(
+                MTKEvent::TransferBatch {
+                    operator: 1.into(),
+                    from: ZERO_ID,
+                    to: account,
+                    ids: ids.to_vec(),
+                    values: amounts.to_vec(),
+                }
+                .encode(),
+            )),
+            MTKAction::Burn { id, amount } => Ok(Some(
+                MTKEvent::TransferSingle(TransferSingleReply {
+                    operator: 1.into(),
+                    from: 1.into(),
+                    to: ZERO_ID,
+                    id,
+                    amount,
+                })
+                .encode(),
+            )),
             MTKAction::BalanceOfBatch {
                 accounts: _,
                 ids: _,
@@ -77,7 +71,7 @@ impl WasmProgram for MultiToken {
                     id: CONCERT_ID,
                     amount: AMOUNT,
                 }];
-                return Ok(Some(MTKEvent::BalanceOfBatch(res).encode()));
+                Ok(Some(MTKEvent::BalanceOfBatch(res).encode()))
             } // _ => return Ok(None),
         }
     }
@@ -95,8 +89,8 @@ pub fn init_system() -> System {
 }
 
 pub fn init_concert(sys: &System) -> Program {
-    let concert_program = Program::current(&sys);
-    let mtk_program = Program::mock_with_id(&sys, MTK_ID, MultiToken);
+    let concert_program = Program::current(sys);
+    let mtk_program = Program::mock_with_id(sys, MTK_ID, MultiToken);
     let res = mtk_program.send_bytes(100001, "INIT");
     assert!(!res.log().is_empty());
     assert!(concert_program

--- a/dao-light/tests/dao_simple_test.rs
+++ b/dao-light/tests/dao_simple_test.rs
@@ -1,6 +1,6 @@
 use codec::Encode;
 use dao_light_io::*;
-use gtest::{Program, System};
+use gtest::System;
 mod utils;
 use utils::*;
 

--- a/dao-light/tests/utils.rs
+++ b/dao-light/tests/utils.rs
@@ -1,13 +1,13 @@
 use dao_light_io::*;
 use ft_io::*;
 use gtest::{Program, RunResult, System};
-pub const MEMBERS: &'static [u64] = &[3, 4, 5, 6];
+pub const MEMBERS: &[u64] = &[3, 4, 5, 6];
 pub const ZERO_ID: u64 = 0;
 
 pub fn init_fungible_token(sys: &System) {
     sys.init_logger();
     let ft = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 
@@ -28,7 +28,7 @@ pub fn init_fungible_token(sys: &System) {
 
 pub fn init_dao(sys: &System) {
     sys.init_logger();
-    let dao = Program::current(&sys);
+    let dao = Program::current(sys);
     let res = dao.send(
         MEMBERS[0],
         InitDao {
@@ -58,13 +58,7 @@ pub fn proposal(dao: &Program, member: u64, applicant: u64, amount: u128) -> Run
 }
 
 pub fn vote(dao: &Program, member: u64, proposal_id: u128, vote: Vote) -> RunResult {
-    dao.send(
-        member,
-        DaoAction::SubmitVote {
-            proposal_id,
-            vote: vote.clone(),
-        },
-    )
+    dao.send(member, DaoAction::SubmitVote { proposal_id, vote })
 }
 
 pub fn process(dao: &Program, member: u64, proposal_id: u128) -> RunResult {
@@ -72,6 +66,5 @@ pub fn process(dao: &Program, member: u64, proposal_id: u128) -> RunResult {
 }
 
 pub fn ragequit(dao: &Program, member: u64, amount: u128) -> RunResult {
-    let res = dao.send(member, DaoAction::RageQuit { amount });
-    res
+    dao.send(member, DaoAction::RageQuit { amount })
 }

--- a/dao-light/tests/utils.rs
+++ b/dao-light/tests/utils.rs
@@ -1,4 +1,3 @@
-use codec::Encode;
 use dao_light_io::*;
 use ft_io::*;
 use gtest::{Program, RunResult, System};

--- a/dao/tests/dao_simple_test.rs
+++ b/dao/tests/dao_simple_test.rs
@@ -6,7 +6,7 @@ use gtest::{Program, System};
 fn init_fungible_token(sys: &System) {
     sys.init_logger();
     let ft = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 
@@ -34,7 +34,7 @@ fn init_fungible_token(sys: &System) {
 
 fn init_dao(sys: &System) {
     sys.init_logger();
-    let dao = Program::current(&sys);
+    let dao = Program::current(sys);
 
     let res = dao.send(
         100001,
@@ -71,7 +71,7 @@ fn create_membership_proposal(dao: &Program, proposal_id: u128) {
         DaoEvent::SubmitMembershipProposal {
             proposer: 3.into(),
             applicant: 4.into(),
-            proposal_id: proposal_id.clone(),
+            proposal_id,
             token_tribute: 1000
         }
         .encode()
@@ -82,7 +82,7 @@ fn vote(dao: &Program, proposal_id: u128, vote: Vote) {
     let res = dao.send(
         3,
         DaoAction::SubmitVote {
-            proposal_id: proposal_id.clone(),
+            proposal_id,
             vote: vote.clone(),
         },
     );
@@ -90,8 +90,8 @@ fn vote(dao: &Program, proposal_id: u128, vote: Vote) {
         3,
         DaoEvent::SubmitVote {
             account: 3.into(),
-            proposal_id: proposal_id.clone(),
-            vote: vote.clone(),
+            proposal_id,
+            vote,
         }
         .encode()
     )));

--- a/dao/tests/funging_proposals.rs
+++ b/dao/tests/funging_proposals.rs
@@ -5,7 +5,7 @@ use gtest::{Program, System};
 
 fn init_fungible_token(sys: &System) {
     let ft = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 
@@ -21,7 +21,7 @@ fn init_fungible_token(sys: &System) {
 }
 
 fn init_dao(sys: &System) {
-    let dao = Program::current(&sys);
+    let dao = Program::current(sys);
     let res = dao.send(
         100001,
         InitDao {
@@ -67,9 +67,9 @@ fn add_member(
         3,
         DaoAction::SubmitMembershipProposal {
             applicant: applicant.into(),
-            token_tribute: token_tribute,
-            shares_requested: shares_requested,
-            quorum: quorum,
+            token_tribute,
+            shares_requested,
+            quorum,
             details: "".to_string(),
         },
     );
@@ -78,7 +78,7 @@ fn add_member(
     let res = dao.send(
         3,
         DaoAction::SubmitVote {
-            proposal_id: proposal_id.clone(),
+            proposal_id,
             vote: Vote::Yes,
         },
     );
@@ -86,7 +86,7 @@ fn add_member(
 
     sys.spend_blocks(1000000001);
 
-    let res = dao.send(3, DaoAction::ProcessProposal(proposal_id.clone()));
+    let res = dao.send(3, DaoAction::ProcessProposal(proposal_id));
     assert!(!res.main_failed());
 }
 

--- a/dutch-auction/tests/dutch_auction_tests.rs
+++ b/dutch-auction/tests/dutch_auction_tests.rs
@@ -2,7 +2,7 @@ use auction_io::*;
 use codec::Encode;
 use gtest::{Program, RunResult, System};
 
-const USERS: &'static [u64] = &[4, 5, 6];
+const USERS: &[u64] = &[4, 5, 6];
 const DURATION: u32 = 7 * 24 * 60 * 60 * 1000;
 
 fn init(sys: &System) -> Program {
@@ -10,7 +10,7 @@ fn init(sys: &System) -> Program {
 
     sys.init_logger();
 
-    let auction_program = Program::current(&sys);
+    let auction_program = Program::current(sys);
 
     auction_program.send(owner_user, InitConfig {});
 
@@ -32,7 +32,7 @@ fn init(sys: &System) -> Program {
 
 fn init_nft(sys: &System, owner: u64) {
     let nft_program = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/nft_example.wasm",
     );
 

--- a/dutch-auction/tests/dutch_auction_tests.rs
+++ b/dutch-auction/tests/dutch_auction_tests.rs
@@ -1,7 +1,6 @@
 use auction_io::*;
 use codec::Encode;
 use gtest::{Program, RunResult, System};
-use primitive_types::U256;
 
 const USERS: &'static [u64] = &[4, 5, 6];
 const DURATION: u32 = 7 * 24 * 60 * 60 * 1000;
@@ -207,6 +206,7 @@ fn create_and_stop() {
     )));
 }
 
+#[test]
 fn stop_from_other_user() {
     let sys = System::new();
     let auction = init(&sys);

--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -22,7 +22,7 @@ pub fn init_system() -> System {
 
 pub fn init_ft(sys: &System) -> Program {
     let ft_program = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 
@@ -41,7 +41,7 @@ pub fn init_ft(sys: &System) -> Program {
 }
 
 pub fn init_escrow(sys: &System) -> Program {
-    let escrow_program = Program::current(&sys);
+    let escrow_program = Program::current(sys);
 
     assert!(escrow_program
         .send(

--- a/fungible-token/src/tests.rs
+++ b/fungible-token/src/tests.rs
@@ -2,12 +2,12 @@ use codec::Encode;
 use ft_io::*;
 use gstd::String;
 use gtest::{Program, System};
-const USERS: &'static [u64] = &[3, 4, 5];
+const USERS: &[u64] = &[3, 4, 5];
 
 fn init_with_mint(sys: &System) {
     sys.init_logger();
 
-    let ft = Program::current(&sys);
+    let ft = Program::current(sys);
 
     let res = ft.send(
         USERS[0],

--- a/lottery/src/panic_tests.rs
+++ b/lottery/src/panic_tests.rs
@@ -7,12 +7,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use codec::Encode;
 use gtest::{Program, System};
 use lt_io::*;
-const USERS: &'static [u64] = &[3, 4, 5, 0];
+const USERS: &[u64] = &[3, 4, 5, 0];
 
 fn init(sys: &System) {
     sys.init_logger();
 
-    let lt = Program::current(&sys);
+    let lt = Program::current(sys);
 
     let res = lt.send_bytes_with_value(USERS[0], b"Init", 10000);
 

--- a/lottery/src/simple_tests.rs
+++ b/lottery/src/simple_tests.rs
@@ -7,12 +7,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use codec::Encode;
 use gtest::{Program, System};
 use lt_io::*;
-const USERS: &'static [u64] = &[3, 4, 5];
+const USERS: &[u64] = &[3, 4, 5];
 
 fn init(sys: &System) {
     sys.init_logger();
 
-    let lt = Program::current(&sys);
+    let lt = Program::current(sys);
 
     let res = lt.send_bytes_with_value(USERS[0], b"Init", 10000);
 

--- a/lottery/src/token_tests.rs
+++ b/lottery/src/token_tests.rs
@@ -8,10 +8,10 @@ use ft_io::*;
 use gstd::String;
 use gtest::{Program, System};
 use lt_io::*;
-const USERS: &'static [u64] = &[1, 2, 3, 4, 5];
+const USERS: &[u64] = &[1, 2, 3, 4, 5];
 
 fn init_lottery(sys: &System) {
-    let lt = Program::current(&sys);
+    let lt = Program::current(sys);
 
     let res = lt.send_bytes_with_value(USERS[2], b"Init", 10000);
 
@@ -20,7 +20,7 @@ fn init_lottery(sys: &System) {
 
 fn init_fungible_token(sys: &System) {
     let ft = Program::from_file(
-        &sys,
+        sys,
         "../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 

--- a/multitoken/tests/mtk_tests.rs
+++ b/multitoken/tests/mtk_tests.rs
@@ -4,7 +4,7 @@ use gstd::{ActorId, String};
 use gtest::{Program, System};
 use multitoken_io::*;
 
-const USERS: &'static [u64] = &[3, 4, 5, 0];
+const USERS: &[u64] = &[3, 4, 5, 0];
 const ZERO_ID: ActorId = ActorId::new([0u8; 32]);
 const TOKEN_AMOUNT: u128 = 100;
 const TOKENS_TO_BURN: u128 = 50;
@@ -13,7 +13,7 @@ const TOKEN_ID: u128 = 0;
 fn init(sys: &System) -> Program {
     sys.init_logger();
 
-    let mtk = Program::current(&sys);
+    let mtk = Program::current(sys);
     let res = mtk.send(
         USERS[0],
         InitMTK {
@@ -24,12 +24,12 @@ fn init(sys: &System) -> Program {
     );
 
     assert!(res.log().is_empty());
-    return mtk;
+    mtk
 }
 
 fn init_with_mint(sys: &System) {
     sys.init_logger();
-    let mtk = Program::current(&sys);
+    let mtk = Program::current(sys);
     let res = mtk.send(
         USERS[0],
         InitMTK {
@@ -94,7 +94,7 @@ fn mint_failures() {
         0,
         MyMTKAction::Mint {
             amount: TOKEN_AMOUNT,
-            token_metadata: Some(meta.clone()),
+            token_metadata: Some(meta),
         },
     );
     assert!(res.main_failed());
@@ -326,7 +326,7 @@ fn balance_of_batch() {
     let res = mtk.send(
         USERS[0],
         MyMTKAction::BalanceOfBatch {
-            accounts: accounts,
+            accounts,
             ids: vec![1u128, 2u128],
         },
     );
@@ -430,7 +430,7 @@ fn transfer_from_failures() {
         from,
         MyMTKAction::TransferFrom {
             from: from.into(),
-            to: ZERO_ID.into(),
+            to: ZERO_ID,
             id: TOKEN_ID,
             amount: 10,
         },
@@ -442,7 +442,7 @@ fn transfer_from_failures() {
         from,
         MyMTKAction::TransferFrom {
             from: from.into(),
-            to: ZERO_ID.into(),
+            to: ZERO_ID,
             id: TOKEN_ID,
             amount: TOKEN_AMOUNT + 100,
         },

--- a/nft-example/tests/nft_tests.rs
+++ b/nft-example/tests/nft_tests.rs
@@ -1,13 +1,13 @@
 use codec::Encode;
 use gtest::{Program, System};
 use nft_example_io::*;
-const USERS: &'static [u64] = &[3, 4, 5];
+const USERS: &[u64] = &[3, 4, 5];
 
 fn init_with_mint(sys: &System) {
     sys.init_logger();
 
     let nft = Program::from_file(
-        &sys,
+        sys,
         "../../apps/target/wasm32-unknown-unknown/release/nft_example.wasm",
     );
 

--- a/nft-marketplace/marketplace/tests/auction.rs
+++ b/nft-marketplace/marketplace/tests/auction.rs
@@ -8,9 +8,9 @@ pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {
-    init_ft(&sys);
-    init_nft(&sys);
-    init_market(&sys);
+    init_ft(sys);
+    init_nft(sys);
+    init_market(sys);
     let nft = sys.get_program(2);
     let market = sys.get_program(3);
     let res = market.send(USERS[0], MarketAction::AddFTContract(1.into()));

--- a/nft-marketplace/marketplace/tests/auction.rs
+++ b/nft-marketplace/marketplace/tests/auction.rs
@@ -4,7 +4,7 @@ use gstd::ActorId;
 use gtest::{Program, RunResult, System};
 use market_io::*;
 use nft_io::*;
-mod utils;
+pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {

--- a/nft-marketplace/marketplace/tests/offers.rs
+++ b/nft-marketplace/marketplace/tests/offers.rs
@@ -8,9 +8,9 @@ pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {
-    init_ft(&sys);
-    init_nft(&sys);
-    init_market(&sys);
+    init_ft(sys);
+    init_nft(sys);
+    init_market(sys);
     let nft = sys.get_program(2);
     let res = nft.send(
         USERS[0],
@@ -61,7 +61,7 @@ fn add_offer() {
     let mut offers = vec![];
     for i in 0..9 {
         offer(&market, USERS[1], None, 1000 * (i + 1));
-        let hash = get_hash(&(2 as u64).into(), None, 1_000 * (i + 1));
+        let hash = get_hash(&2_u64.into(), None, 1_000 * (i + 1));
         offers.push(Offer {
             hash,
             id: USERS[1].into(),

--- a/nft-marketplace/marketplace/tests/offers.rs
+++ b/nft-marketplace/marketplace/tests/offers.rs
@@ -4,7 +4,7 @@ use gstd::ActorId;
 use gtest::{Program, System};
 use market_io::*;
 use nft_io::*;
-mod utils;
+pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {

--- a/nft-marketplace/marketplace/tests/sale.rs
+++ b/nft-marketplace/marketplace/tests/sale.rs
@@ -8,9 +8,9 @@ pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {
-    init_ft(&sys);
-    init_nft(&sys);
-    init_market(&sys);
+    init_ft(sys);
+    init_nft(sys);
+    init_market(sys);
     let market = sys.get_program(3);
     let res = market.send(USERS[0], MarketAction::AddFTContract(1.into()));
     assert!(res.log().is_empty());

--- a/nft-marketplace/marketplace/tests/sale.rs
+++ b/nft-marketplace/marketplace/tests/sale.rs
@@ -1,11 +1,10 @@
 use codec::Encode;
 use ft_io::*;
-use gstd::ActorId;
 use market_io::*;
 use nft_io::*;
 
-use gtest::{Program, System};
-mod utils;
+use gtest::System;
+pub mod utils;
 use utils::*;
 
 fn before_each_test(sys: &System) {

--- a/nft-marketplace/marketplace/tests/utils.rs
+++ b/nft-marketplace/marketplace/tests/utils.rs
@@ -6,12 +6,12 @@ use market_io::*;
 use nft_io::*;
 use primitive_types::H256;
 
-pub const USERS: &'static [u64] = &[4, 5, 6, 7];
+pub const USERS: &[u64] = &[4, 5, 6, 7];
 pub const TREASURY_ID: u64 = 8;
 
 pub fn init_ft(sys: &System) {
     let ft = Program::from_file(
-        &sys,
+        sys,
         "../../target/wasm32-unknown-unknown/release/fungible_token.wasm",
     );
 
@@ -28,7 +28,7 @@ pub fn init_ft(sys: &System) {
 
 pub fn init_nft(sys: &System) {
     sys.init_logger();
-    let nft = Program::from_file(&sys, "../../target/wasm32-unknown-unknown/release/nft.wasm");
+    let nft = Program::from_file(sys, "../../target/wasm32-unknown-unknown/release/nft.wasm");
 
     let res = nft.send(
         USERS[0],
@@ -45,7 +45,7 @@ pub fn init_nft(sys: &System) {
 
 pub fn init_market(sys: &System) {
     sys.init_logger();
-    let market = Program::current(&sys);
+    let market = Program::current(sys);
     let res = market.send(
         USERS[0],
         InitMarket {


### PR DESCRIPTION
- Enables the clippy linter for all targets by using the `--all-targets` flag.
- Fixes all occured warnings.